### PR TITLE
fix: update openid_connect version

### DIFF
--- a/apple_id.gemspec
+++ b/apple_id.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'json-jwt', '~> 1.16'
   spec.add_runtime_dependency 'rack-oauth2', '~> 2.0'
-  spec.add_runtime_dependency 'openid_connect', '~> 2.0'
+  spec.add_runtime_dependency 'openid_connect', '~> 2.2'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
Fix warning issue that leads to a runtime error with Spring

`/usr/local/bundle/gems/net-protocol-0.2.1/lib/net/protocol.rb:68: warning: already initialized constant Net::ProtocRetryError`

[known issue](https://github.com/ruby/net-imap/issues/16)